### PR TITLE
Update versions of packages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,7 @@ package = "kzen-paillier"
 default-features = false
 
 [dependencies.multi-party-ecdsa]
-# git = "https://github.com/webb-tools/multi-party-ecdsa"
-path = "../multi-party-ecdsa"
+git = "https://github.com/webb-tools/multi-party-ecdsa"
 default-features = false
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,33 +3,29 @@ name = "fs-dkr"
 version = "0.1.0"
 authors = [
     "Omer Shlomovits <omer.shlomovits@gmail.com>",
-    "Tudor Cebere <tudorcebere@gmail.com>"
+    "Tudor Cebere <tudorcebere@gmail.com>",
+    "Drew Stone <drew@webb.tools>",
 ]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-
-
 [dependencies.paillier]
-git = "https://github.com/KZen-networks/rust-paillier"
-tag = "v0.3.10"
-default-features = false
-
-[dependencies.zk-paillier]
-git = "https://github.com/KZen-networks/zk-paillier"
-tag = "v0.3.12"
+version = "0.4.2"
+package = "kzen-paillier"
 default-features = false
 
 [dependencies.multi-party-ecdsa]
-git = "https://github.com/ZenGo-X/multi-party-ecdsa"
-tag = "v0.7.1"
+# git = "https://github.com/webb-tools/multi-party-ecdsa"
+path = "../multi-party-ecdsa"
 default-features = false
 
 [dependencies]
-curv = { package = "curv-kzen", version = "0.7", default-features = true }
+zk-paillier = { version = "0.4.3", default-features = false }
+curv = { package = "curv-kzen", version = "0.9", default-features = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_derive = "1.0"
 zeroize = "1"
 round-based = { version = "0.1.4", features = ["dev"] }
 thiserror = "1.0.26"
+sha2 = "0.9"

--- a/src/add_party_message.rs
+++ b/src/add_party_message.rs
@@ -33,7 +33,7 @@ use zk_paillier::zkproofs::{CompositeDLogProof, DLogStatement, NiCorrectKeyProof
 pub struct JoinMessage {
     pub(crate) ek: EncryptionKey,
     pub(crate) dk_correctness_proof: NiCorrectKeyProof,
-    pub party_index: Option<u16>,
+    pub(crate) party_index: Option<u16>,
     pub(crate) dlog_statement_base_h1: DLogStatement,
     pub(crate) dlog_statement_base_h2: DLogStatement,
     pub(crate) composite_dlog_proof_base_h1: CompositeDLogProof,
@@ -94,6 +94,9 @@ fn generate_dlog_statement_proofs() -> (
 }
 
 impl JoinMessage {
+    pub fn set_party_index(&mut self, new_party_index: u16) {
+        self.party_index = Some(new_party_index);
+    }
     /// The distribute phase for a new party. This distribute phase has to happen before the existing
     /// parties distribute. Calling this function will generate a JoinMessage and a pair of Paillier
     /// [Keys] that are going to be used when generating the [LocalKey].

--- a/src/add_party_message.rs
+++ b/src/add_party_message.rs
@@ -1,6 +1,6 @@
 //! Message definitions for new parties that can join the protocol
 //! Key points about a new party joining the refresh protocol:
-//! * A new party wants to join, broadcasting a pailier ek, correctness of the ek generation,
+//! * A new party wants to join, broadcasting a paillier ek, correctness of the ek generation,
 //! dlog statements and dlog proofs.
 //! * All the existing parties receives the join message. We assume for now that everyone accepts
 //! the new party. All parties pick an index and add the new ek to their LocalKey at the given index.
@@ -95,10 +95,10 @@ fn generate_dlog_statement_proofs() -> (
 
 impl JoinMessage {
     /// The distribute phase for a new party. This distribute phase has to happen before the existing
-    /// parties distribute. Calling this function will generate a JoinMessage and a pair of Pailier
+    /// parties distribute. Calling this function will generate a JoinMessage and a pair of Paillier
     /// [Keys] that are going to be used when generating the [LocalKey].
     pub fn distribute() -> (Self, Keys) {
-        let pailier_key_pair = Keys::create(0);
+        let paillier_key_pair = Keys::create(0);
         let (
             dlog_statement_base_h1,
             dlog_statement_base_h2,
@@ -108,8 +108,8 @@ impl JoinMessage {
 
         let join_message = JoinMessage {
             // in a join message, we only care about the ek and the correctness proof
-            ek: pailier_key_pair.ek.clone(),
-            dk_correctness_proof: NiCorrectKeyProof::proof(&pailier_key_pair.dk, None),
+            ek: paillier_key_pair.ek.clone(),
+            dk_correctness_proof: NiCorrectKeyProof::proof(&paillier_key_pair.dk, None),
             dlog_statement_base_h1,
             dlog_statement_base_h2,
             composite_dlog_proof_base_h1,
@@ -117,7 +117,7 @@ impl JoinMessage {
             party_index: None,
         };
 
-        (join_message, pailier_key_pair)
+        (join_message, paillier_key_pair)
     }
     /// Returns the party index if it has been assigned one, throws
     /// [FsDkrError::NewPartyUnassignedIndexError] otherwise

--- a/src/add_party_message.rs
+++ b/src/add_party_message.rs
@@ -33,7 +33,7 @@ use zk_paillier::zkproofs::{CompositeDLogProof, DLogStatement, NiCorrectKeyProof
 pub struct JoinMessage {
     pub(crate) ek: EncryptionKey,
     pub(crate) dk_correctness_proof: NiCorrectKeyProof,
-    pub(crate) party_index: Option<u16>,
+    pub party_index: Option<u16>,
     pub(crate) dlog_statement_base_h1: DLogStatement,
     pub(crate) dlog_statement_base_h2: DLogStatement,
     pub(crate) composite_dlog_proof_base_h1: CompositeDLogProof,

--- a/src/add_party_message.rs
+++ b/src/add_party_message.rs
@@ -196,6 +196,7 @@ impl JoinMessage {
         let available_parties: HashMap<u16, &EncryptionKey> = refresh_messages
             .iter()
             .map(|msg| (msg.party_index, &msg.ek))
+            .chain(std::iter::once((party_index, &paillier_key.ek)))
             .chain(
                 join_messages
                     .iter()
@@ -203,12 +204,15 @@ impl JoinMessage {
             )
             .collect();
 
+        println!("available parties {:?}", available_parties.len());
+
         // TODO: submit the statement the dlog proof as well!
         // check what parties are assigned in the current rotation and associate their DLogStatements
         // and check their CompositeDlogProofs.
         let available_h1_h2_ntilde_vec: HashMap<u16, &DLogStatement> = refresh_messages
             .iter()
             .map(|msg| (msg.party_index, &msg.dlog_statement))
+            .chain(std::iter::once((party_index, &self.dlog_statement_base_h1)))
             .chain(join_messages.iter().map(|join_message| {
                 (
                     join_message.party_index.unwrap(),

--- a/src/add_party_message.rs
+++ b/src/add_party_message.rs
@@ -196,7 +196,6 @@ impl JoinMessage {
         let available_parties: HashMap<u16, &EncryptionKey> = refresh_messages
             .iter()
             .map(|msg| (msg.party_index, &msg.ek))
-            .chain(std::iter::once((party_index, &paillier_key.ek)))
             .chain(
                 join_messages
                     .iter()
@@ -210,7 +209,6 @@ impl JoinMessage {
         let available_h1_h2_ntilde_vec: HashMap<u16, &DLogStatement> = refresh_messages
             .iter()
             .map(|msg| (msg.party_index, &msg.dlog_statement))
-            .chain(std::iter::once((party_index, &self.dlog_statement_base_h1)))
             .chain(join_messages.iter().map(|join_message| {
                 (
                     join_message.party_index.unwrap(),

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,7 +2,7 @@ use thiserror::Error;
 
 pub type FsDkrResult<T> = Result<T, FsDkrError>;
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Clone)]
 pub enum FsDkrError {
     #[error("Too many malicious parties detected! Threshold {threshold:?}, Number of Refreshed Messages: {refreshed_keys:?}, Malicious parties detected when trying to refresh: malicious_parties:?")]
     PartiesThresholdViolation {

--- a/src/error.rs
+++ b/src/error.rs
@@ -30,7 +30,7 @@ pub enum FsDkrError {
     },
 
     #[error("Paillier verification proof failed for party {party_index:?}")]
-    PaillierVerificationError { party_index: usize },
+    PaillierVerificationError { party_index: u16 },
 
     #[error("A new party did not receive a valid index.")]
     NewPartyUnassignedIndexError,
@@ -39,5 +39,5 @@ pub enum FsDkrError {
     BroadcastedPublicKeyError,
 
     #[error("DLog proof failed for party {party_index:?}")]
-    DLogProofValidation { party_index: usize },
+    DLogProofValidation { party_index: u16 },
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,4 +18,4 @@ pub mod add_party_message;
 pub mod error;
 pub mod proof_of_fairness;
 pub mod refresh_message;
-mod test;
+// mod test;

--- a/src/refresh_message.rs
+++ b/src/refresh_message.rs
@@ -200,6 +200,7 @@ impl<E: Curve, H: Digest + Clone> RefreshMessage<E, H> {
     pub fn replace(
         new_parties: &[JoinMessage],
         key: &mut LocalKey<E>,
+        new_n: u16,
     ) -> FsDkrResult<(Self, DecryptionKey)> {
         for join_message in new_parties.iter() {
             let party_index = join_message.get_party_index()?;
@@ -208,7 +209,7 @@ impl<E: Curve, H: Digest + Clone> RefreshMessage<E, H> {
                 
         }
 
-        RefreshMessage::distribute(key, new_parties.len() as u16)
+        RefreshMessage::distribute(key, new_n as u16)
     }
 
     pub fn collect(

--- a/src/refresh_message.rs
+++ b/src/refresh_message.rs
@@ -167,6 +167,8 @@ impl<E: Curve, H: Digest + Clone> RefreshMessage<E, H> {
         let indices: Vec<u16> = (0..(parameters.threshold + 1) as usize)
             .map(|i| refresh_messages[i].party_index - 1)
             .collect();
+        
+        println!("indices {:?}", indices);
 
         // optimization - one decryption
         let li_vec: Vec<_> = (0..parameters.threshold as usize + 1)
@@ -213,9 +215,7 @@ impl<E: Curve, H: Digest + Clone> RefreshMessage<E, H> {
             } else {
                 key.paillier_key_vec.insert((party_index - 1) as usize, join_message.ek.clone());
                 key.h1_h2_n_tilde_vec.insert((party_index - 1) as usize, join_message.dlog_statement_base_h1.clone());
-            }
-
-                
+            }      
         }
 
         RefreshMessage::distribute(key, new_n as u16)

--- a/src/refresh_message.rs
+++ b/src/refresh_message.rs
@@ -216,13 +216,14 @@ impl<E: Curve, H: Digest + Clone> RefreshMessage<E, H> {
         refresh_messages: &[Self],
         mut local_key: &mut LocalKey<E>,
         new_dk: DecryptionKey,
+        new_n: u16,
         join_messages: &[JoinMessage],
     ) -> FsDkrResult<()> {
-        RefreshMessage::validate_collect(refresh_messages, local_key.t, local_key.n)?;
+        RefreshMessage::validate_collect(refresh_messages, local_key.t, new_n)?;
 
         let mut statement: FairnessStatement<E>;
         for refresh_message in refresh_messages.iter() {
-            for i in 0..local_key.n as usize {
+            for i in 0..new_n as usize {
                 statement = FairnessStatement {
                     ek: local_key.paillier_key_vec[i].clone(),
                     c: refresh_message.points_encrypted_vec[i].clone(),
@@ -299,7 +300,7 @@ impl<E: Curve, H: Digest + Clone> RefreshMessage<E, H> {
         local_key.keys_linear.y = Point::<E>::generator() * new_share_fe;
 
         // update local key list of local public keys (X_i = g^x_i is updated by adding all committed points to that party)
-        for i in 0..local_key.n as usize {
+        for i in 0..new_n as usize {
             local_key.pk_vec[i] =
                 refresh_messages[0].points_committed_vec[i].clone() * li_vec[0].clone();
             for j in 1..local_key.t as usize + 1 {

--- a/src/refresh_message.rs
+++ b/src/refresh_message.rs
@@ -205,7 +205,7 @@ impl<E: Curve, H: Digest + Clone> RefreshMessage<E, H> {
         let current_len = key.paillier_key_vec.len() as u16;
         for join_message in new_parties.iter() {
             let party_index = join_message.get_party_index()?;
-            if party_index < current_len {
+            if party_index <= current_len {
                 key.paillier_key_vec.remove((party_index - 1) as usize,);
                 key.paillier_key_vec.insert((party_index - 1) as usize, join_message.ek.clone());
                 key.h1_h2_n_tilde_vec.remove((party_index - 1) as usize,);

--- a/src/refresh_message.rs
+++ b/src/refresh_message.rs
@@ -202,10 +202,19 @@ impl<E: Curve, H: Digest + Clone> RefreshMessage<E, H> {
         key: &mut LocalKey<E>,
         new_n: u16,
     ) -> FsDkrResult<(Self, DecryptionKey)> {
+        let current_len = key.paillier_key_vec.len() as u16;
         for join_message in new_parties.iter() {
             let party_index = join_message.get_party_index()?;
-            key.paillier_key_vec.insert((party_index - 1) as usize, join_message.ek.clone());
-            key.h1_h2_n_tilde_vec.insert((party_index - 1) as usize, join_message.dlog_statement_base_h1.clone());
+            if party_index < current_len {
+                key.paillier_key_vec.remove((party_index - 1) as usize,);
+                key.paillier_key_vec.insert((party_index - 1) as usize, join_message.ek.clone());
+                key.h1_h2_n_tilde_vec.remove((party_index - 1) as usize,);
+                key.h1_h2_n_tilde_vec.insert((party_index - 1) as usize, join_message.dlog_statement_base_h1.clone());
+            } else {
+                key.paillier_key_vec.insert((party_index - 1) as usize, join_message.ek.clone());
+                key.h1_h2_n_tilde_vec.insert((party_index - 1) as usize, join_message.dlog_statement_base_h1.clone());
+            }
+
                 
         }
 

--- a/src/refresh_message.rs
+++ b/src/refresh_message.rs
@@ -300,7 +300,7 @@ impl<E: Curve, H: Digest + Clone> RefreshMessage<E, H> {
         local_key.keys_linear.y = Point::<E>::generator() * new_share_fe;
 
         // update local key list of local public keys (X_i = g^x_i is updated by adding all committed points to that party)
-        for i in 0..new_n as usize {
+        for i in 0..refresh_messages.len() as usize {
             local_key.pk_vec[i] =
                 refresh_messages[0].points_committed_vec[i].clone() * li_vec[0].clone();
             for j in 1..local_key.t as usize + 1 {

--- a/src/refresh_message.rs
+++ b/src/refresh_message.rs
@@ -39,11 +39,11 @@ pub struct RefreshMessage<E: Curve, H: Digest + Clone> {
 }
 
 impl<E: Curve, H: Digest + Clone> RefreshMessage<E, H> {
-    pub fn distribute(local_key: &LocalKey<E>) -> (Self, DecryptionKey) {
+    pub fn distribute(local_key: &LocalKey<E>, num_of_new_parties: u16) -> (Self, DecryptionKey) {
         let secret = local_key.keys_linear.x_i.clone();
         // secret share old key
         let (vss_scheme, secret_shares) =
-            VerifiableSS::<E>::share(local_key.t, local_key.n, &secret);
+            VerifiableSS::<E>::share(local_key.t, local_key.n + num_of_new_parties, &secret);
 
         // commit to points on the polynomial
         let points_committed_vec: Vec<_> = (0..secret_shares.len())
@@ -205,7 +205,7 @@ impl<E: Curve, H: Digest + Clone> RefreshMessage<E, H> {
                 
         }
 
-        Ok(RefreshMessage::distribute(key))
+        Ok(RefreshMessage::distribute(key, new_parties.len() as u16))
     }
 
     pub fn collect(

--- a/src/refresh_message.rs
+++ b/src/refresh_message.rs
@@ -200,9 +200,9 @@ impl<E: Curve, H: Digest + Clone> RefreshMessage<E, H> {
     ) -> FsDkrResult<(Self, DecryptionKey)> {
         for join_message in new_parties.iter() {
             let party_index = join_message.get_party_index()?;
-            key.paillier_key_vec[(party_index - 1) as usize] = join_message.ek.clone();
-            key.h1_h2_n_tilde_vec[(party_index - 1) as usize] =
-                join_message.dlog_statement_base_h1.clone();
+            key.paillier_key_vec.insert((party_index - 1) as usize, join_message.ek.clone());
+            key.h1_h2_n_tilde_vec.insert((party_index - 1) as usize, join_message.dlog_statement_base_h1.clone());
+                
         }
 
         Ok(RefreshMessage::distribute(key))

--- a/src/refresh_message.rs
+++ b/src/refresh_message.rs
@@ -216,10 +216,10 @@ impl<E: Curve, H: Digest + Clone> RefreshMessage<E, H> {
         refresh_messages: &[Self],
         mut local_key: &mut LocalKey<E>,
         new_dk: DecryptionKey,
-        new_n: u16,
         join_messages: &[JoinMessage],
     ) -> FsDkrResult<()> {
-        RefreshMessage::validate_collect(refresh_messages, local_key.t, new_n)?;
+        let new_n = refresh_messages.len() + join_messages.len();
+        RefreshMessage::validate_collect(refresh_messages, local_key.t, new_n as u16)?;
 
         let mut statement: FairnessStatement<E>;
         for refresh_message in refresh_messages.iter() {

--- a/src/refresh_message.rs
+++ b/src/refresh_message.rs
@@ -22,7 +22,7 @@ use zeroize::{DefaultIsZeroes, Zeroize};
 use zk_paillier::zkproofs::{DLogStatement, NiCorrectKeyProof, SALT_STRING};
 
 // Everything here can be broadcasted
-#[derive(Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct RefreshMessage<E: Curve, H: Digest + Clone> {
     pub(crate) party_index: usize,
     fairness_proof_vec: Vec<FairnessProof<E, H>>,

--- a/src/test.rs
+++ b/src/test.rs
@@ -160,7 +160,7 @@ mod tests {
         let mut keys = all_keys[0..5].to_vec();
 
         simulate_replace(&mut keys, &[6, 7], t as usize, n as usize).unwrap();
-        let offline_sign = simulate_offline_stage(keys, &[1, 2, 7]);
+        let offline_sign = simulate_offline_stage(keys, &[1, 6, 7]);
         simulate_signing(offline_sign, b"ZenGo");
     }
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -159,8 +159,8 @@ mod tests {
         let all_keys = simulate_keygen(t, n);
         let mut keys = all_keys[0..5].to_vec();
 
-        simulate_replace(&mut keys, &[6, 7], t as usize, n as usize).unwrap();
-        let offline_sign = simulate_offline_stage(keys, &[1, 6, 7]);
+        simulate_replace(&mut keys, &[2, 7], t as usize, n as usize).unwrap();
+        let offline_sign = simulate_offline_stage(keys, &[1, 2, 7]);
         simulate_signing(offline_sign, b"ZenGo");
     }
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -159,7 +159,7 @@ mod tests {
         let all_keys = simulate_keygen(t, n);
         let mut keys = all_keys[0..5].to_vec();
 
-        simulate_replace(&mut keys, &[2, 7], t as usize, n as usize).unwrap();
+        simulate_replace(&mut keys, &[6, 7], t as usize, n as usize).unwrap();
         let offline_sign = simulate_offline_stage(keys, &[1, 2, 7]);
         simulate_signing(offline_sign, b"ZenGo");
     }

--- a/src/test.rs
+++ b/src/test.rs
@@ -158,22 +158,9 @@ mod tests {
 
         let all_keys = simulate_keygen(t, n);
         // Remove the 2nd and 7th party
-        let mut keys = Vec::<LocalKey<Secp256k1>>::new();
-        // Add 1st party
-        keys.push(all_keys[0].clone());
-        assert_eq!(keys[0].i, 1);
-        // Add 3rd party
-        keys.push(all_keys[2].clone());
-        assert_eq!(keys[1].i, 3);
-        // Add 4th party
-        keys.push(all_keys[3].clone());
-        assert_eq!(keys[2].i, 4);
-        // Add 5th party
-        keys.push(all_keys[4].clone());
-        assert_eq!(keys[3].i, 5);
-        // Add 6th party
-        keys.push(all_keys[5].clone());
-        assert_eq!(keys[4].i, 6);
+        let mut keys = all_keys.clone();
+        keys.remove(6);
+        keys.remove(1);
 
         // Simulate the replace
         simulate_replace(&mut keys, &[2, 7], t, n).unwrap();

--- a/src/test.rs
+++ b/src/test.rs
@@ -157,30 +157,26 @@ mod tests {
         let n = 7;
 
         let all_keys = simulate_keygen(t, n);
-        let mut keys = all_keys[0..5].to_vec();
-        // check that sum of old keys is equal to sum of new keys
-        let old_linear_secret_key: Vec<_> = (0..keys.len())
-            .map(|i| keys[i].keys_linear.x_i.clone())
-            .collect();
+        // Remove the 2nd and 7th party
+        let mut keys = Vec::<LocalKey<Secp256k1>>::new();
+        // Add 1st party
+        keys.push(all_keys[0].clone());
+        assert_eq!(keys[0].i, 1);
+        // Add 3rd party
+        keys.push(all_keys[2].clone());
+        assert_eq!(keys[1].i, 3);
+        // Add 4th party
+        keys.push(all_keys[3].clone());
+        assert_eq!(keys[2].i, 4);
+        // Add 5th party
+        keys.push(all_keys[4].clone());
+        assert_eq!(keys[3].i, 5);
+        // Add 6th party
+        keys.push(all_keys[5].clone());
+        assert_eq!(keys[4].i, 6);
 
+        // Simulate the replace
         simulate_replace(&mut keys, &[2, 7], t, n).unwrap();
-
-        let new_linear_secret_key: Vec<_> = (0..keys.len())
-            .map(|i| keys[i].keys_linear.x_i.clone())
-            .collect();
-        let indices: Vec<_> = (0..(t + 1) as u16).collect();
-        let vss = VerifiableSS::<Secp256k1> {
-            parameters: ShamirSecretSharing {
-                threshold: t,
-                share_count: n,
-            },
-            commitments: Vec::new(),
-        };
-        assert_eq!(
-            vss.reconstruct(&indices[..], &old_linear_secret_key[0..(t + 1) as usize]),
-            vss.reconstruct(&indices[..], &new_linear_secret_key[0..(t + 1) as usize])
-        );
-        assert_ne!(old_linear_secret_key, new_linear_secret_key);
 
         let offline_sign = simulate_offline_stage(keys, &[1, 2, 7]);
         simulate_signing(offline_sign, b"ZenGo");

--- a/src/test.rs
+++ b/src/test.rs
@@ -111,7 +111,7 @@ mod tests {
                     .unzip()
             }
 
-            // each party that wants to join generates a join message and a pair of pailier keys.
+            // each party that wants to join generates a join message and a pair of paillier keys.
             let (mut join_messages, new_keys) =
                 generate_join_messages_and_keys(party_indices.len());
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -2,12 +2,11 @@
 mod tests {
     use crate::refresh_message::RefreshMessage;
     use curv::arithmetic::Converter;
-    use curv::cryptographic_primitives::hashing::hash_sha256::HSha256;
-    use curv::cryptographic_primitives::hashing::traits::Hash;
     use curv::cryptographic_primitives::secret_sharing::feldman_vss::{
         ShamirSecretSharing, VerifiableSS,
     };
-    use curv::elliptic::curves::secp256_k1::GE;
+    use curv::elliptic::curves::secp256_k1::Secp256k1Point;
+    use curv::elliptic::curves::Secp256k1;
     use curv::BigInt;
     use multi_party_ecdsa::protocols::multi_party_ecdsa::gg_2020::party_i::verify;
     use multi_party_ecdsa::protocols::multi_party_ecdsa::gg_2020::party_i::Keys;
@@ -17,12 +16,15 @@ mod tests {
     use multi_party_ecdsa::protocols::multi_party_ecdsa::gg_2020::state_machine::sign::{
         CompletedOfflineStage, OfflineStage, SignManual,
     };
+    use sha2::{Digest, Sha256};
 
     use crate::add_party_message::JoinMessage;
     use crate::error::FsDkrResult;
     use paillier::DecryptionKey;
     use round_based::dev::Simulation;
     use std::collections::HashMap;
+
+    type GE = Secp256k1Point;
 
     #[test]
     fn test1() {
@@ -36,16 +38,17 @@ mod tests {
 
         // check that sum of old keys is equal to sum of new keys
         let old_linear_secret_key: Vec<_> = (0..old_keys.len())
-            .map(|i| old_keys[i].keys_linear.x_i)
+            .map(|i| old_keys[i].keys_linear.x_i.clone())
             .collect();
 
-        let new_linear_secret_key: Vec<_> =
-            (0..keys.len()).map(|i| keys[i].keys_linear.x_i).collect();
-        let indices: Vec<_> = (0..(t + 1) as usize).collect();
-        let vss = VerifiableSS::<GE> {
+        let new_linear_secret_key: Vec<_> = (0..keys.len())
+            .map(|i| keys[i].keys_linear.x_i.clone())
+            .collect();
+        let indices: Vec<_> = (0..(t + 1) as u16).collect();
+        let vss = VerifiableSS::<Secp256k1> {
             parameters: ShamirSecretSharing {
-                threshold: t as usize,
-                share_count: n as usize,
+                threshold: t as u16,
+                share_count: n as u16,
             },
             commitments: Vec::new(),
         };
@@ -85,7 +88,7 @@ mod tests {
     #[test]
     fn test_add_party() {
         fn simulate_replace(
-            keys: &mut Vec<LocalKey>,
+            keys: &mut Vec<LocalKey<Secp256k1>>,
             party_indices: &[usize],
             t: usize,
             n: usize,
@@ -100,9 +103,9 @@ mod tests {
             }
 
             fn generate_refresh_parties_replace(
-                keys: &mut [LocalKey],
+                keys: &mut [LocalKey<Secp256k1>],
                 join_messages: &[JoinMessage],
-            ) -> (Vec<RefreshMessage<GE>>, Vec<DecryptionKey>) {
+            ) -> (Vec<RefreshMessage<Secp256k1, Sha256>>, Vec<DecryptionKey>) {
                 keys.iter_mut()
                     .map(|key| RefreshMessage::replace(join_messages, key).unwrap())
                     .unzip()
@@ -161,7 +164,7 @@ mod tests {
         simulate_signing(offline_sign, b"ZenGo");
     }
 
-    fn simulate_keygen(t: u16, n: u16) -> Vec<LocalKey> {
+    fn simulate_keygen(t: u16, n: u16) -> Vec<LocalKey<Secp256k1>> {
         //simulate keygen
         let mut simulation = Simulation::new();
         simulation.enable_benchmarks(false);
@@ -173,11 +176,12 @@ mod tests {
         simulation.run().unwrap()
     }
 
-    fn simulate_dkr_removal(keys: &mut Vec<LocalKey>, remove_party_indices: Vec<usize>) {
-        let mut broadcast_messages: HashMap<usize, Vec<RefreshMessage<GE>>> = HashMap::new();
+    fn simulate_dkr_removal(keys: &mut Vec<LocalKey<Secp256k1>>, remove_party_indices: Vec<usize>) {
+        let mut broadcast_messages: HashMap<usize, Vec<RefreshMessage<Secp256k1, Sha256>>> =
+            HashMap::new();
         let mut new_dks: HashMap<usize, DecryptionKey> = HashMap::new();
-        let mut refresh_messages: Vec<RefreshMessage<GE>> = Vec::new();
-        let mut party_key: HashMap<usize, LocalKey> = HashMap::new();
+        let mut refresh_messages: Vec<RefreshMessage<Secp256k1, Sha256>> = Vec::new();
+        let mut party_key: HashMap<usize, LocalKey<Secp256k1>> = HashMap::new();
 
         for key in keys.iter_mut() {
             let (refresh_message, new_dk) = RefreshMessage::distribute(key);
@@ -237,8 +241,10 @@ mod tests {
         }
     }
 
-    fn simulate_dkr(keys: &mut Vec<LocalKey>) -> (Vec<RefreshMessage<GE>>, Vec<DecryptionKey>) {
-        let mut broadcast_vec: Vec<RefreshMessage<GE>> = Vec::new();
+    fn simulate_dkr(
+        keys: &mut Vec<LocalKey<Secp256k1>>,
+    ) -> (Vec<RefreshMessage<Secp256k1, Sha256>>, Vec<DecryptionKey>) {
+        let mut broadcast_vec: Vec<RefreshMessage<Secp256k1, Sha256>> = Vec::new();
         let mut new_dks: Vec<DecryptionKey> = Vec::new();
 
         for key in keys.iter() {
@@ -257,7 +263,7 @@ mod tests {
     }
 
     fn simulate_offline_stage(
-        local_keys: Vec<LocalKey>,
+        local_keys: Vec<LocalKey<Secp256k1>>,
         s_l: &[u16],
     ) -> Vec<CompletedOfflineStage> {
         let mut simulation = Simulation::new();
@@ -278,8 +284,8 @@ mod tests {
     }
 
     fn simulate_signing(offline: Vec<CompletedOfflineStage>, message: &[u8]) {
-        let message = HSha256::create_hash(&[&BigInt::from_bytes(message)]);
-        let pk = *offline[0].public_key();
+        let message = create_hash(&[&BigInt::from_bytes(message)]);
+        let pk = &offline[0].public_key();
 
         let parties = offline
             .iter()
@@ -302,5 +308,16 @@ mod tests {
             .enumerate()
             .map(|(i, p)| p.complete(&local_sigs_except(i)).unwrap())
             .all(|signature| verify(&signature, &pk, &message).is_ok()));
+    }
+
+    fn create_hash(big_ints: &[&BigInt]) -> BigInt {
+        let hasher = Sha256::new();
+
+        for value in big_ints {
+            hasher.clone().chain(&BigInt::to_bytes(value));
+        }
+
+        let result_hex = hasher.finalize();
+        BigInt::from_bytes(&result_hex[..])
     }
 }


### PR DESCRIPTION
# Overview
Updates all packages to the latest versions they have in the other repos so that it's consistent with `multi-party-ecdsa` master. It is needed to generalize some types to make this consistent there as well.

Would appreciate reviews if possible. All but one tests are passing at the moment. Currently, the failing test is:
```
running 6 tests
test proof_of_fairness::tests::test_bad_fairness_proof - should panic ... ok
test proof_of_fairness::tests::test_fairness_proof ... ok
test test::tests::test1 ... ok
test test::tests::test_add_party ... FAILED
test test::tests::test_remove_sign_rotate_sign ... ok
test test::tests::test_sign_rotate_sign ... ok

failures:

---- test::tests::test_add_party stdout ----
thread 'test::tests::test_add_party' panicked at 'Incorrect Alice's range proof in MtA: InvalidKey', /Users/drew/webb/multi-party-ecdsa/src/protocols/multi_party_ecdsa/gg_2020/state_machine/sign/rounds.rs:156:14
```

Namely, it fails to `simulate_offline`: https://github.com/webb-tools/fs-dkr/blob/drew/update-versions/src/test.rs#L162-L164
```
simulate_replace(&mut keys, &[2, 7], t as usize, n as usize).unwrap();
let offline_sign = simulate_offline_stage(keys, &[1, 2, 7]);
simulate_signing(offline_sign, b"ZenGo");
```